### PR TITLE
Truncate branch name to 50 chars

### DIFF
--- a/make-pr.sh
+++ b/make-pr.sh
@@ -42,7 +42,7 @@ then
 fi
 
 
-issue_title_cleaned=$(echo "$issue_title" | sed "s/ /_/g" | tr '[:upper:]' '[:lower:]')
+issue_title_cleaned=$(echo "$issue_title" | sed "s/ /_/g" | tr '[:upper:]' '[:lower:]' | cut -c 1-50 )
 
 branch_name="$issue"_"$issue_title_cleaned"
 


### PR DESCRIPTION
Git nenechá vytvořit branch s příliš dlouhým názvem. Přidala jsem `cut` na 50 znaků.